### PR TITLE
Issues starting up containers with docker compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -95,4 +95,4 @@ services:
       ## Development Environment Optimizations
       SITECORE_DEVELOPMENT_PATCHES: DevEnvOn,CustomErrorsOff,DebugOn,DiagnosticsOff,InitMessagesOff
       Sitecore_AppSettings_exmEnabled:define: "no" # remove to turn on EXM
-    entrypoint: powershell -Command "& C:\tools\entrypoints\iis\Development.ps1"
+    entrypoint: powershell -Command "& C:/tools/entrypoints/iis/Development.ps1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     healthcheck:
       test: ["CMD", "traefik", "healthcheck", "--ping"]
     volumes:
-      - source: \\.\pipe\docker_engine
-        target: \\.\pipe\docker_engine
+      - source: \\.\pipe\docker_engine\
+        target: \\.\pipe\docker_engine\
         type: npipe
       - ./traefik:C:/etc/traefik
     depends_on:


### PR DESCRIPTION
Two specific issues have appeared repeatedly on my two laptops running Windows 10 and 11. 

- Entrypoint command fails with back slashes in the path.
- Traefik volume needs either a trailing back slash or single quotes.