### PR TITLE
Add ClientCredentials flow and switcher

### DIFF
--- a/.env
+++ b/.env
@@ -64,6 +64,8 @@ MEDIA_REQUEST_PROTECTION_SHARED_SECRET=
 # SITECORE_FedAuth_dot_Auth0_dot_Domain=https://auth-staging-1.sitecore-staging.cloud
 # SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-staging.sitecore-staging.cloud;https://xmcloud-cm-staging.sitecore-staging.cloud
 # SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
+# SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=False
+# SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=
 
 # Sitecore XM Cloud Fed Auth configuration - PRE-PROD
 SITECORE_FedAuth_dot_Auth0_dot_RedirectBaseUrl=https://xmcloudcm.localhost/
@@ -73,6 +75,8 @@ SITECORE_FedAuth_dot_Auth0_dot_ClientSecret=qasWWubfPROthbtZoaK4mV_TKpb3Ya50oBQX
 SITECORE_FedAuth_dot_Auth0_dot_Domain=https://auth-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-beta.sitecorecloud.io;https://xmcloud-cm-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
+SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=False
+SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=
 
 # Experience Editor Graph QL Configuration
 SITECORE_API_KEY=B2F8A9B9-7203-4DCF-9314-8B28B043347E

--- a/.env
+++ b/.env
@@ -65,7 +65,10 @@ MEDIA_REQUEST_PROTECTION_SHARED_SECRET=
 # SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-staging.sitecore-staging.cloud;https://xmcloud-cm-staging.sitecore-staging.cloud
 # SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
 # SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin=false
-# SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin=
+# SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientId=
+# SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientSecret=
+# SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_Audience=
+# SITECORE_XmCloud_dot_OrganizationId=
 
 # Sitecore XM Cloud Fed Auth configuration - PRE-PROD
 SITECORE_FedAuth_dot_Auth0_dot_RedirectBaseUrl=https://xmcloudcm.localhost/
@@ -76,7 +79,10 @@ SITECORE_FedAuth_dot_Auth0_dot_Domain=https://auth-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-beta.sitecorecloud.io;https://xmcloud-cm-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
 SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin=false
-SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin=
+SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientId=
+SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientSecret=
+SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_Audience=
+SITECORE_XmCloud_dot_OrganizationId=
 
 # Experience Editor Graph QL Configuration
 SITECORE_API_KEY=B2F8A9B9-7203-4DCF-9314-8B28B043347E

--- a/.env
+++ b/.env
@@ -64,7 +64,7 @@ MEDIA_REQUEST_PROTECTION_SHARED_SECRET=
 # SITECORE_FedAuth_dot_Auth0_dot_Domain=https://auth-staging-1.sitecore-staging.cloud
 # SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-staging.sitecore-staging.cloud;https://xmcloud-cm-staging.sitecore-staging.cloud
 # SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
-# SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=False
+# SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=false
 # SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=
 
 # Sitecore XM Cloud Fed Auth configuration - PRE-PROD
@@ -75,7 +75,7 @@ SITECORE_FedAuth_dot_Auth0_dot_ClientSecret=qasWWubfPROthbtZoaK4mV_TKpb3Ya50oBQX
 SITECORE_FedAuth_dot_Auth0_dot_Domain=https://auth-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-beta.sitecorecloud.io;https://xmcloud-cm-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
-SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=False
+SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=false
 SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=
 
 # Experience Editor Graph QL Configuration

--- a/.env
+++ b/.env
@@ -64,8 +64,8 @@ MEDIA_REQUEST_PROTECTION_SHARED_SECRET=
 # SITECORE_FedAuth_dot_Auth0_dot_Domain=https://auth-staging-1.sitecore-staging.cloud
 # SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-staging.sitecore-staging.cloud;https://xmcloud-cm-staging.sitecore-staging.cloud
 # SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
-# SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=false
-# SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=
+# SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin=false
+# SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin=
 
 # Sitecore XM Cloud Fed Auth configuration - PRE-PROD
 SITECORE_FedAuth_dot_Auth0_dot_RedirectBaseUrl=https://xmcloudcm.localhost/
@@ -75,8 +75,8 @@ SITECORE_FedAuth_dot_Auth0_dot_ClientSecret=qasWWubfPROthbtZoaK4mV_TKpb3Ya50oBQX
 SITECORE_FedAuth_dot_Auth0_dot_Domain=https://auth-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_Audience=https://api-beta.sitecorecloud.io;https://xmcloud-cm-beta.sitecorecloud.io
 SITECORE_FedAuth_dot_Auth0_dot_LogoutRedirect=/sitecore
-SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=false
-SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=
+SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin=false
+SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin=
 
 # Experience Editor Graph QL Configuration
 SITECORE_API_KEY=B2F8A9B9-7203-4DCF-9314-8B28B043347E

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See Sitecore Containers documentation for more information on system requirement
 
 1. When prompted, log into Sitecore via your browser, and
    accept the device authorization.
-    * To log in via client credentials flow, set the environment variable SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin to "true" and update values of the correspond environment variables (SITECORE_FedAuth_dot_Auth0_dot_Domain, SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin, SITECORE_FedAuth_dot_Auth0_dot_ClientId, SITECORE_FedAuth_dot_Auth0_dot_ClientSecret)
+    * To log in via client credentials flow, set the environment variable SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin to "true" and update values of the correspond environment variables (SITECORE_FedAuth_dot_Auth0_dot_Domain, SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientId, SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientSecret, SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_Audience, SITECORE_XmCloud_dot_OrganizationId)
 
 1. Wait for the startup script to open browser tabs for the rendered site
    and Sitecore Launchpad.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ See Sitecore Containers documentation for more information on system requirement
 
 1. When prompted, log into Sitecore via your browser, and
    accept the device authorization.
+    * To log in via client credentials flow, set the environment variable SITECORE_FedAuth_dot_Auth0_dot_SilentLogin to "true" and update values of the correspond environment variables (Domain, AudienceForSilentLogin, ClientId, ClientSecret)
 
 1. Wait for the startup script to open browser tabs for the rendered site
    and Sitecore Launchpad.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See Sitecore Containers documentation for more information on system requirement
 
 1. When prompted, log into Sitecore via your browser, and
    accept the device authorization.
-    * To log in via client credentials flow, set the environment variable SITECORE_FedAuth_dot_Auth0_dot_SilentLogin to "true" and update values of the correspond environment variables (Domain, AudienceForSilentLogin, ClientId, ClientSecret)
+    * To log in via client credentials flow, set the environment variable SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin to "true" and update values of the correspond environment variables (SITECORE_FedAuth_dot_Auth0_dot_Domain, SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin, SITECORE_FedAuth_dot_Auth0_dot_ClientId, SITECORE_FedAuth_dot_Auth0_dot_ClientSecret)
 
 1. Wait for the startup script to open browser tabs for the rendered site
    and Sitecore Launchpad.

--- a/up.ps1
+++ b/up.ps1
@@ -75,12 +75,12 @@ foreach ($pluginJsonFile in $pluginJsonFiles) {
 
 Write-Host "Logging into Sitecore..." -ForegroundColor Green
 if ($SilentLogin) {
-    dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAud --client-id $AuthClientId --client-secret $AuthClientSecret --client-credentials
+    dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAud --client-id $AuthClientId --client-secret $AuthClientSecret --client-credentials --allow-write true
 }
 else {
     dotnet sitecore cloud login
+	dotnet sitecore login --ref xmcloud --cm https://$xmCloudHost --allow-write true
 }
-dotnet sitecore login --ref xmcloud --cm https://$xmCloudHost --allow-write true
 
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Unable to log into Sitecore, did the Sitecore environment start correctly? See logs above."

--- a/up.ps1
+++ b/up.ps1
@@ -1,9 +1,3 @@
-Param (
-    [switch]$SilentLogin,
-    [string]$AuthClientId,
-    [string]$AuthClientSecret,
-    [string]$xmCloudAud
-)
 $ErrorActionPreference = "Stop";
 
 $envContent = Get-Content .env -Encoding UTF8
@@ -11,13 +5,24 @@ $xmCloudHost = $envContent | Where-Object { $_ -imatch "^CM_HOST=.+" }
 $xmCloudDeployConfig = $envContent | Where-Object { $_ -imatch "^XMCLOUDDEPLOY_CONFIG=.+" }
 $sitecoreDockerRegistry = $envContent | Where-Object { $_ -imatch "^SITECORE_DOCKER_REGISTRY=.+" }
 $sitecoreVersion = $envContent | Where-Object { $_ -imatch "^SITECORE_VERSION=.+" }
-$xmCloudDomain = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_Domain=.+" }
+$SilentLogin = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=.+" }
 
 $xmCloudHost = $xmCloudHost.Split("=")[1]
 $xmCloudDeployConfig = $xmCloudDeployConfig.Split("=")[1]
 $sitecoreDockerRegistry = $sitecoreDockerRegistry.Split("=")[1]
 $sitecoreVersion = $sitecoreVersion.Split("=")[1]
-$xmCloudDomain = $xmCloudDomain.Split("=")[1]
+$SilentLogin = $SilentLogin.Split("=")[1]
+if ($SilentLogin -eq "true") {
+	$xmCloudDomain = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_Domain=.+" }
+	$xmCloudAudSilentLogin = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=.+" }
+	$xmCloudClientId = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientId=.+" }
+	$xmCloudClientSecret = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientSecret=.+" }
+	$xmCloudDomain = $xmCloudDomain.Split("=")[1]
+	$xmCloudAudSilentLogin = $xmCloudAudSilentLogin.Split("=")[1]
+	$xmCloudClientId = $xmCloudClientId.Split("=")[1]
+	$xmCloudClientSecret = $xmCloudClientSecret.Split("=")[1]
+}
+
 
 # Double check whether init has been run
 $envCheckVariable = "HOST_LICENSE_FOLDER"
@@ -74,8 +79,8 @@ foreach ($pluginJsonFile in $pluginJsonFiles) {
 }
 
 Write-Host "Logging into Sitecore..." -ForegroundColor Green
-if ($SilentLogin) {
-    dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAud --client-id $AuthClientId --client-secret $AuthClientSecret --client-credentials --allow-write true
+if ($SilentLogin -eq "true") {
+    dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAudSilentLogin --client-id $xmCloudClientId --client-secret $xmCloudClientSecret --client-credentials
 }
 else {
     dotnet sitecore cloud login

--- a/up.ps1
+++ b/up.ps1
@@ -5,20 +5,20 @@ $xmCloudHost = $envContent | Where-Object { $_ -imatch "^CM_HOST=.+" }
 $xmCloudDeployConfig = $envContent | Where-Object { $_ -imatch "^XMCLOUDDEPLOY_CONFIG=.+" }
 $sitecoreDockerRegistry = $envContent | Where-Object { $_ -imatch "^SITECORE_DOCKER_REGISTRY=.+" }
 $sitecoreVersion = $envContent | Where-Object { $_ -imatch "^SITECORE_VERSION=.+" }
-$SilentLogin = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_SilentLogin=.+" }
+$ClientCredentialsLogin = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin=.+" }
 
 $xmCloudHost = $xmCloudHost.Split("=")[1]
 $xmCloudDeployConfig = $xmCloudDeployConfig.Split("=")[1]
 $sitecoreDockerRegistry = $sitecoreDockerRegistry.Split("=")[1]
 $sitecoreVersion = $sitecoreVersion.Split("=")[1]
-$SilentLogin = $SilentLogin.Split("=")[1]
-if ($SilentLogin -eq "true") {
+$ClientCredentialsLogin = $ClientCredentialsLogin.Split("=")[1]
+if ($ClientCredentialsLogin -eq "true") {
 	$xmCloudDomain = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_Domain=.+" }
-	$xmCloudAudSilentLogin = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_AudienceForSilentLogin=.+" }
+	$xmCloudAudienceForClientCredentialsLogin = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin=.+" }
 	$xmCloudClientId = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientId=.+" }
 	$xmCloudClientSecret = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientSecret=.+" }
 	$xmCloudDomain = $xmCloudDomain.Split("=")[1]
-	$xmCloudAudSilentLogin = $xmCloudAudSilentLogin.Split("=")[1]
+	$xmCloudAudienceForClientCredentialsLogin = $xmCloudAudienceForClientCredentialsLogin.Split("=")[1]
 	$xmCloudClientId = $xmCloudClientId.Split("=")[1]
 	$xmCloudClientSecret = $xmCloudClientSecret.Split("=")[1]
 }
@@ -79,12 +79,12 @@ foreach ($pluginJsonFile in $pluginJsonFiles) {
 }
 
 Write-Host "Logging into Sitecore..." -ForegroundColor Green
-if ($SilentLogin -eq "true") {
-    dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAudSilentLogin --client-id $xmCloudClientId --client-secret $xmCloudClientSecret --client-credentials
+if ($ClientCredentialsLogin -eq "true") {
+    dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAudienceForClientCredentialsLogin --client-id $xmCloudClientId --client-secret $xmCloudClientSecret --client-credentials
 }
 else {
     dotnet sitecore cloud login
-	dotnet sitecore login --ref xmcloud --cm https://$xmCloudHost --allow-write true
+    dotnet sitecore login --ref xmcloud --cm https://$xmCloudHost --allow-write true
 }
 
 if ($LASTEXITCODE -ne 0) {

--- a/up.ps1
+++ b/up.ps1
@@ -81,6 +81,7 @@ foreach ($pluginJsonFile in $pluginJsonFiles) {
 Write-Host "Logging into Sitecore..." -ForegroundColor Green
 if ($ClientCredentialsLogin -eq "true") {
     dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAudienceForClientCredentialsLogin --client-id $xmCloudClientId --client-secret $xmCloudClientSecret --client-credentials
+    dotnet sitecore login --authority $xmCloudDomain --audience $xmCloudAudienceForClientCredentialsLogin --client-id $xmCloudClientId --client-secret $xmCloudClientSecret --client-credentials true --allow-write true
 }
 else {
     dotnet sitecore cloud login

--- a/up.ps1
+++ b/up.ps1
@@ -13,14 +13,14 @@ $sitecoreDockerRegistry = $sitecoreDockerRegistry.Split("=")[1]
 $sitecoreVersion = $sitecoreVersion.Split("=")[1]
 $ClientCredentialsLogin = $ClientCredentialsLogin.Split("=")[1]
 if ($ClientCredentialsLogin -eq "true") {
-	$xmCloudDomain = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_Domain=.+" }
-	$xmCloudAudienceForClientCredentialsLogin = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_AudienceForClientCredentialsLogin=.+" }
-	$xmCloudClientId = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientId=.+" }
-	$xmCloudClientSecret = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientSecret=.+" }
-	$xmCloudDomain = $xmCloudDomain.Split("=")[1]
-	$xmCloudAudienceForClientCredentialsLogin = $xmCloudAudienceForClientCredentialsLogin.Split("=")[1]
-	$xmCloudClientId = $xmCloudClientId.Split("=")[1]
-	$xmCloudClientSecret = $xmCloudClientSecret.Split("=")[1]
+	$xmCloudClientCredentialsLoginDomain = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_Domain=.+" }
+	$xmCloudClientCredentialsLoginAudience = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_Audience=.+" }
+	$xmCloudClientCredentialsLoginClientId = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientId=.+" }
+	$xmCloudClientCredentialsLoginClientSecret = $envContent | Where-Object { $_ -imatch "^SITECORE_FedAuth_dot_Auth0_dot_ClientCredentialsLogin_ClientSecret=.+" }
+	$xmCloudClientCredentialsLoginDomain = $xmCloudClientCredentialsLoginDomain.Split("=")[1]
+	$xmCloudClientCredentialsLoginAudience = $xmCloudClientCredentialsLoginAudience.Split("=")[1]
+	$xmCloudClientCredentialsLoginClientId = $xmCloudClientCredentialsLoginClientId.Split("=")[1]
+	$xmCloudClientCredentialsLoginClientSecret = $xmCloudClientCredentialsLoginClientSecret.Split("=")[1]
 }
 
 
@@ -80,8 +80,8 @@ foreach ($pluginJsonFile in $pluginJsonFiles) {
 
 Write-Host "Logging into Sitecore..." -ForegroundColor Green
 if ($ClientCredentialsLogin -eq "true") {
-    dotnet sitecore cloud login --authority $xmCloudDomain --audience $xmCloudAudienceForClientCredentialsLogin --client-id $xmCloudClientId --client-secret $xmCloudClientSecret --client-credentials
-    dotnet sitecore login --authority $xmCloudDomain --audience $xmCloudAudienceForClientCredentialsLogin --client-id $xmCloudClientId --client-secret $xmCloudClientSecret --client-credentials true --allow-write true
+    dotnet sitecore cloud login --client-id $xmCloudClientCredentialsLoginClientId --client-secret $xmCloudClientCredentialsLoginClientSecret --client-credentials true
+    dotnet sitecore login --authority $xmCloudClientCredentialsLoginDomain --audience $xmCloudClientCredentialsLoginAudience --client-id $xmCloudClientCredentialsLoginClientId --client-secret $xmCloudClientCredentialsLoginClientSecret --cm https://$xmCloudHost --client-credentials true --allow-write true
 }
 else {
     dotnet sitecore cloud login
@@ -146,12 +146,12 @@ if (Test-Path .\src\items\content) {
     Write-Host "Pulling JSS deployed items..." -ForegroundColor Green
     dotnet sitecore ser pull
 }
-
-Write-Host "Opening site..." -ForegroundColor Green
-
-Start-Process https://xmcloudcm.localhost/sitecore/
-Start-Process https://www.xmcloudpreview.localhost/
-
+if ($ClientCredentialsLogin -ne "true") {
+    Write-Host "Opening site..." -ForegroundColor Green
+    
+    Start-Process https://xmcloudcm.localhost/sitecore/
+    Start-Process https://www.xmcloudpreview.localhost/
+}
 Write-Host ""
 Write-Host "Use the following command to monitor your Rendering Host:" -ForegroundColor Green
 Write-Host "docker-compose logs -f rendering"


### PR DESCRIPTION
Added variables to .env file;
Added description to Readme file;
Updated up.ps1 file:
- if ClientCredentials flow is used, get correspond variables
- if ClientCredentials flow is used, login via ClientCredentials, else - via UI interface
- if ClientCredentials flow is not used, open sites