### PR TITLE
Fix directory iteration bug in PS script

### DIFF
--- a/docker/build/cm/templates/import-templates.ps1
+++ b/docker/build/cm/templates/import-templates.ps1
@@ -20,7 +20,7 @@ if(Test-Path $modulesPath) {
 
 Copy-Item -Path (Join-Path $PSScriptRoot "modules_template") -Destination $modulesPath -Recurse -Force
 Copy-Item -Path ".\.sitecore"  -Destination $PSScriptRoot -Recurse -Force
-$files = Get-ChildItem -Path $modulesPath -Recurse -File
+$files = Get-ChildItem -Path $modulesPath -Recurse -File | ForEach-Object {$_.FullName}
 foreach ($item in $files) {
     (Get-Content -Path $item -Encoding UTF8).Replace("<SITENAME>",$RenderingSiteName).Replace("<SITECORE-API-KEY>", $SitecoreApiKey) `
     | Set-Content -Path $item -Encoding UTF8


### PR DESCRIPTION
The import_templates.ps1 script attempted to replace the `<SITENAME>` and `<SITECORE-API-KEY>` tokens by calling the `Get-Content` and `Set-Content` cmdlets on a stringified version of the file objects, which yields just the file name. It's necessary to get the full file paths for this iteration because otherwise we get a file not found error.